### PR TITLE
Combine assertion hooks with ASan output

### DIFF
--- a/preload/harness/src/firefox_hooks.c
+++ b/preload/harness/src/firefox_hooks.c
@@ -19,9 +19,10 @@ __attribute__((noreturn)) void firefox_handler_MOZ_CRASH(const char* aFilename,
 #ifndef CATCH_MOZ_CRASH
   kAFL_hypercall(HYPERCALL_KAFL_RELEASE, 0);
 #endif
-  hprintf("MOZ_CRASH catched! (%d - %s)\n", aLine, aFilename);
-  sprintf(log_content, "MOZ_CRASH catched! (%d - %s)\n", aLine, aFilename);
-  kAFL_hypercall(HYPERCALL_KAFL_PANIC_EXTENDED, (uint64_t)log_content);
+  hprintf("Caught MOZ_CRASH at %s:%d\n", aFilename, aLine);
+  sprintf(log_content, "Hit MOZ_CRASH() at %s:%d\n", aFilename, aLine);
+  // Trigger a crash to also emit a trace through ASan
+  *((volatile int*)0x1) = aLine;
   while (1) {
   }
 }
@@ -32,10 +33,11 @@ __attribute__((noreturn)) void firefox_handler_MOZ_ASSERT(const char* aFilename,
 #ifndef CATCH_MOZ_ASSERT
   kAFL_hypercall(HYPERCALL_KAFL_RELEASE, 0);
 #endif
-  hprintf("MOZ_ASSERT catched! (%s - %d - %s)\n", aReason, aLine, aFilename);
-  sprintf(log_content, "MOZ_ASSERT catched! (%s - %d - %s)\n", aReason, aLine,
-          aFilename);
-  kAFL_hypercall(HYPERCALL_KAFL_PANIC_EXTENDED, (uint64_t)log_content);
+  hprintf("Caught MOZ_ASSERT(%s) at %s:%d\n", aReason, aFilename, aLine);
+  sprintf(log_content, "Assertion failure: %s, at %s:%d\n", aReason, aFilename,
+          aLine);
+  // Trigger a crash to also emit a trace through ASan
+  *((volatile int*)0x1) = aLine;
   while (1) {
   }
 }
@@ -45,11 +47,12 @@ __attribute__((noreturn)) void firefox_handler_MOZ_RELEASE_ASSERT(
 #ifndef CATCH_MOZ_RELEASE_ASSERT
   kAFL_hypercall(HYPERCALL_KAFL_RELEASE, 0);
 #endif
-  hprintf("MOZ_RELEASE_ASSERT catched! (%s - %d - %s)\n", aReason, aLine,
-          aFilename);
-  sprintf(log_content, "MOZ_RELEASE_ASSERT catched! (%s - %d - %s)\n", aReason,
-          aLine, aFilename);
-  kAFL_hypercall(HYPERCALL_KAFL_PANIC_EXTENDED, (uint64_t)log_content);
+  hprintf("Caught MOZ_RELEASE_ASSERT(%s) at %s:%d\n", aReason, aFilename,
+          aLine);
+  sprintf(log_content, "Assertion failure: %s, at %s:%d\n", aReason, aFilename,
+          aLine);
+  // Trigger a crash to also emit a trace through ASan
+  *((volatile int*)0x1) = aLine;
   while (1) {
   }
 }
@@ -59,11 +62,12 @@ __attribute__((noreturn)) void firefox_handler_MOZ_DIAGNOSTIC_ASSERT(
 #ifndef CATCH_MOZ_DIAGNOSTIC_ASSERT
   kAFL_hypercall(HYPERCALL_KAFL_RELEASE, 0);
 #endif
-  hprintf("MOZ_DIAGNOSTIC_ASSERT catched! (%s - %d - %s)\n", aReason, aLine,
-          aFilename);
-  sprintf(log_content, "MOZ_DIAGNOSTIC_ASSERT catched! (%s - %d - %s)\n",
-          aReason, aLine, aFilename);
-  kAFL_hypercall(HYPERCALL_KAFL_PANIC_EXTENDED, (uint64_t)log_content);
+  hprintf("Caught MOZ_DIAGNOSTIC_ASSERT(%s) at %s:%d\n", aReason, aFilename,
+          aLine);
+  sprintf(log_content, "Assertion failure: %s, at %s:%d\n", aReason, aFilename,
+          aLine);
+  // Trigger a crash to also emit a trace through ASan
+  *((volatile int*)0x1) = aLine;
   while (1) {
   }
 }


### PR DESCRIPTION
Currently, when catching e.g. a `MOZ_DIAGNOSTIC_ASSERT`, we immediately panic without getting a stack. Also, the output format of the asserts don't match up with what Firefox would output without the preloader.

This patch fixes both the output format to match what Firefox itself does and it also chains a crash after the assert so we can obtain an ASan trace for better processing in automation.